### PR TITLE
Fix broken link in code-to-code.md

### DIFF
--- a/contents/ja/basic/code-to-code.md
+++ b/contents/ja/basic/code-to-code.md
@@ -30,7 +30,7 @@ function calculateSum(a, b) {
 ## GitHub Copilot の参照優先度
 
 GitHub Copilot は直近開いたいくつかの同じ言語のファイルを参照し、類似性を計算してプロンプトに含めるファイルを決定します。
-現在ロジックは非公開になっていますが、[リバースエンジニアリングの手記](https://thakkarparth007.github.io/GitHub Copilot-explorer/posts/GitHub Copilot-internals.html#how-is-the-prompt-prepared-a-code-walkthrough)などがありますので、ご覧ください。
+現在ロジックは非公開になっていますが、[リバースエンジニアリングの手記](https://thakkarparth007.github.io/copilot-explorer/posts/copilot-internals#how-is-the-prompt-prepared-a-code-walkthrough)などがありますので、ご覧ください。
 
 ## Note 
 


### PR DESCRIPTION
I've updated a link to `リバースエンジニアリングの手記` in `code-to-code.md`.